### PR TITLE
Accept wider Node JS versions

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Typescript starter template for hardhat, ethers and react projects using typescript and @web3-react",
   "engines": {
-    "node": "16.13.1",
+    "node": "^16.13.1",
     "npm": "8.1.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "description": "Typescript starter template for hardhat, ethers and react projects using typescript and @web3-react",
   "engines": {
-    "node": "16.13.1",
+    "node": "^16.13.1",
     "npm": "8.1.2"
   },
   "devDependencies": {


### PR DESCRIPTION
The existing setting prevents you from using any Node JS versions except `16.13.1`. Would like it to accept wider Node JS versions.